### PR TITLE
pyproject: Relax python requirement to 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 click = "~8.1.7"
 websockets = "~13.0.1"
 pydantic_core = "~2.20.1"


### PR DESCRIPTION
There's no need to insist on 3.12. This version is not available by default in many distros (e.g. debian stable). This simple patch downgrades this requirement to 3.11 that is more widely available. 